### PR TITLE
The PVS Studio static analyzer tool has found several issues

### DIFF
--- a/Calculations/MovingAvg.cs
+++ b/Calculations/MovingAvg.cs
@@ -3578,7 +3578,7 @@ public static partial class Calculations
             decimal output = 0;
             for (int j = 1; j <= length; j++)
             {
-                decimal sign = (0.5m * (1 - Cos(MinOrMax(j / length * Pi, 0.99m, 0.01m))));
+                decimal sign = (0.5m * (1 - Cos(MinOrMax((decimal)j / length * Pi, 0.99m, 0.01m))));
                 decimal d = sign - (0.5m * (1 - Cos(MinOrMax((decimal)(j - 1) / length, 0.99m, 0.01m))));
                 decimal prevValue = i >= j - 1 ? inputList.ElementAtOrDefault(i - (j - 1)) : 0;
                 output += ((sign * prevOutput) + ((1 - sign) * prevValue)) * d;
@@ -4292,7 +4292,7 @@ public static partial class Calculations
             int vLength = (int)Math.Round(Math.Max(kRescaled, 1));
 
             decimal sum = 0, weightedSum = 0;
-            for (int j = 0; i <= vLength - 1; i++)
+            for (int j = 0; j <= vLength - 1; j++)
             {
                 decimal weight = vLength - j;
                 decimal prevValue = i >= j ? inputList.ElementAtOrDefault(i - j) : 0;

--- a/Calculations/Oscillator.cs
+++ b/Calculations/Oscillator.cs
@@ -7127,7 +7127,7 @@ public static partial class Calculations
             logList.Add(log);
 
             decimal logSum = logList.TakeLastExt(length).Sum();
-            decimal gcv = Sqrt(i / length * logSum);
+            decimal gcv = Sqrt((decimal)i / length * logSum);
             gcvList.Add(gcv);
         }
 
@@ -7840,13 +7840,13 @@ public static partial class Calculations
             decimal prevValue = i >= 1 ? inputList.ElementAtOrDefault(i - 1) : 0;
 
             decimal fastF1x = (decimal)(i + 1) / length;
-            decimal fastF1b = 1 / (i + 1) * Sin(fastF1x * (i + 1) * Pi);
+            decimal fastF1b = 1m / (i + 1) * Sin(fastF1x * (i + 1) * Pi);
             fastF1bList.Add(fastF1b);
 
             decimal fastF1bSum = fastF1bList.TakeLastExt(fastLength).Sum();
             decimal fastF1pol = (fastF1x * fastF1x) + fastF1bSum;
             decimal fastF2x = (decimal)i / length;
-            decimal fastF2b = 1 / (i + 1) * Sin(fastF2x * (i + 1) * Pi);
+            decimal fastF2b = 1m / (i + 1) * Sin(fastF2x * (i + 1) * Pi);
             fastF2bList.Add(fastF2b);
 
             decimal fastF2bSum = fastF2bList.TakeLastExt(fastLength).Sum();
@@ -7857,13 +7857,13 @@ public static partial class Calculations
 
             decimal fastVWSum = fastVWList.TakeLastExt(length).Sum();
             decimal slowF1x = (decimal)(i + 1) / length;
-            decimal slowF1b = 1 / (i + 1) * Sin(slowF1x * (i + 1) * Pi);
+            decimal slowF1b = 1m / (i + 1) * Sin(slowF1x * (i + 1) * Pi);
             slowF1bList.Add(slowF1b);
 
             decimal slowF1bSum = slowF1bList.TakeLastExt(slowLength).Sum();
             decimal slowF1pol = (slowF1x * slowF1x) + slowF1bSum;
             decimal slowF2x = (decimal)i / length;
-            decimal slowF2b = 1 / (i + 1) * Sin(slowF2x * (i + 1) * Pi);
+            decimal slowF2b = 1m / (i + 1) * Sin(slowF2x * (i + 1) * Pi);
             slowF2bList.Add(slowF2b);
 
             decimal slowF2bSum = slowF2bList.TakeLastExt(slowLength).Sum();


### PR DESCRIPTION
The PVS Studio static analyzer tool has found several issues in the code. There are fixes for some of them:

- One place in `CalculateVariableMovingAverage` looks like a copy-paste error - may be incorrect loop variable used?
- A lot of integer/integer division issues - in most cases such divisions will produce zero or just incorrect/unexpected results.